### PR TITLE
Add auto-observe on one resource of each instance and object. Devices…

### DIFF
--- a/leshan-server-demo/nb-configuration.xml
+++ b/leshan-server-demo/nb-configuration.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <netbeans.hint.jdkPlatform>JDK_13</netbeans.hint.jdkPlatform>
+    </properties>
+</project-shared-configuration>

--- a/leshan-server-demo/pom.xml
+++ b/leshan-server-demo/pom.xml
@@ -136,6 +136,15 @@ Contributors:
                     </replacements>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>13</source>
+                    <target>13</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
… that supports auto-observe: Weather, presence, radiator and light. Shows some wierd behaviour when auto-observing. Some devices never gets observe requests. Also, observing all resources of instances throws formatting errors and gets 4.04 and 4.05 responses from devices